### PR TITLE
Admin_get_layouts () - no files found, glob() returns false

### DIFF
--- a/apps/admin/lib/Functions.php
+++ b/apps/admin/lib/Functions.php
@@ -40,9 +40,11 @@ function admin_get_layouts () {
 	);
 	foreach ($sources as $source) {
 		$files = glob ($source);
-		foreach ($files as $file) {
-			if (preg_match ('/\/([^\/]+)\.html$/', $file, $regs)) {
-				$layouts[] = $regs[1];
+		if ($files) {
+			foreach ($files as $file) {
+				if (preg_match ('/\/([^\/]+)\.html$/', $file, $regs)) {
+					$layouts[] = $regs[1];
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Admin_get_layouts() fails if glob() returns false: Debugger::handle_error (2, "Invalid argument supplied for foreach()", "/apps/admin/lib/Functions.php", 43, array(6))
