### PR TITLE
OpenID truncation issue

### DIFF
--- a/conf/install_mysql.sql
+++ b/conf/install_mysql.sql
@@ -44,7 +44,7 @@ create table user (
 insert into user (id, email, password, session_id, expires, name, type, signed_up, updated, userdata) values (1, 'you@example.com', '$2a$07$1QeR9mu2doQxY0uBcpFlrOIfDxq0BwpR8FsImCgWvAL4Fz9jDByxi', null, now(), 'Admin User', 'admin', now(), now(), '[]');
 
 create table user_openid (
-	token char(128) primary key,
+	token char(200) primary key,
 	user_id int not null
 ) default charset=utf8;
 

--- a/conf/install_pgsql.sql
+++ b/conf/install_pgsql.sql
@@ -53,7 +53,7 @@ create index user_session_id on "user" (session_id);
 insert into "user" (id, email, password, session_id, expires, name, type, signed_up, updated, userdata) values (1, 'you@example.com', '$2a$07$1QeR9mu2doQxY0uBcpFlrOIfDxq0BwpR8FsImCgWvAL4Fz9jDByxi', null, now(), 'Admin User', 'admin', now(), now(), '[]');
 
 create table user_openid (
-	token varchar(128) primary key,
+	token varchar(200) primary key,
 	user_id integer not null
 );
 

--- a/conf/install_sqlite.sql
+++ b/conf/install_sqlite.sql
@@ -47,7 +47,7 @@ create index user_session_id on user (session_id);
 insert into user (id, email, password, session_id, expires, name, type, signed_up, updated, userdata) values (1, 'you@example.com', '$2a$07$1QeR9mu2doQxY0uBcpFlrOIfDxq0BwpR8FsImCgWvAL4Fz9jDByxi', null, (DATETIME('now')), 'Admin User', 'admin', (DATETIME('now')), (DATETIME('now')), '[]');
 
 create table user_openid (
-	token char(128) primary key,
+	token char(200) primary key,
 	user_id int not null
 );
 


### PR DESCRIPTION
With Facebook, the token field was actually too short, and would cutoff the token, preventing a valid login for ever occurring again. Fixed by updating the token field in user_openid to 200 chars, up from 128.
