### PR TITLE
Sanity check (prevent call array_fill if an array is empty)

### DIFF
--- a/apps/filemanager/handlers/gallery.php
+++ b/apps/filemanager/handlers/gallery.php
@@ -50,9 +50,11 @@ foreach ($files as $key => $file) {
 
 // fetch descriptions
 if ($data['desc'] === 'yes') {
-	$descriptions = FileManager::prop (array_keys ($list), 'desc');
-	foreach ($descriptions as $file => $desc) {
-		$list[$file]->desc = $desc;
+	if (!empty ($list)) {
+		$descriptions = FileManager::prop (array_keys ($list), 'desc');
+		foreach ($descriptions as $file => $desc) {
+			$list[$file]->desc = $desc;
+		}
 	}
 }
 


### PR DESCRIPTION
Missed commit from previous pull request - if there are empty directory, we can have a call like array_fill(0,0,'?') @ FileManager::prop and an exception. Sanity check required.
