### PR TITLE
Add Apps to Navigation

### DIFF
--- a/apps/navigation/lib/Functions.php
+++ b/apps/navigation/lib/Functions.php
@@ -87,6 +87,21 @@ function navigation_clear_cache () {
 function navigation_get_other_pages ($ids) {
 	$pages = array ();
 	$res = DB::fetch ('select id, title, menu_title from #prefix#webpage where access = "public"');
+	
+	//Adds apps to Navigation
+        $apps = glob('apps/*/conf/config.php');
+        foreach ($apps as $app) {
+            $ini = parse_ini_file($app);
+            if (key_exists('title',$ini) && !key_exists('no_nav',$ini)){
+                $appObj = new stdClass();
+                $appPath = explode('/',$app);
+                $appObj->id = $appPath[0];
+                $appObj->title = $ini['title'];
+                $appObj->menu_title = key_exists('menu_title',$ini) ? $ini['menu_title'] : $ini['title'];
+                $res[] = $appObj;
+            }
+        }
+        
 	foreach ($res as $p) {
 		if (in_array ($p->id, $ids)) {
 			// skip if in tree


### PR DESCRIPTION
![Elefant CMS - Navigation](https://f.cloud.github.com/assets/3902182/320818/fc05588a-996b-11e2-839a-c905d606a5c2.png)
Allows Elefant Apps to be added to the Navigation.  It simply adds all Apps that have a `title` (but no `no_nav` key) in their `conf.php` to the list of selectable items.

To me, the current way of adding Apps to the Navigation using redirects seems a bit odd as the navigation URL will be different from the actual URL.
