### PR TITLE
Add Apps to Navigation

### DIFF
--- a/apps/navigation/lib/Functions.php
+++ b/apps/navigation/lib/Functions.php
@@ -92,8 +92,8 @@ function navigation_get_other_pages ($ids) {
         $apps = glob('apps/*/conf/config.php');
         foreach ($apps as $app) {
             $ini = parse_ini_file($app);
-            if (key_exists('title',$ini) && $ini['title']!=''
-                && !(key_exists('no_nav',$ini) && (bool)$ini['no_nav'])) {
+             if (array_key_exists ('include_in_nav', $ini) && $ini['include_in_nav']
+            		&& array_key_exists ('title', $ini) && $ini['title'] != '') {
                 $appObj = new stdClass();
                 $appPath = explode('/',$app);
                 $appObj->id = $appPath[1];


### PR DESCRIPTION
![Elefant CMS - Navigation](https://f.cloud.github.com/assets/3902182/320913/849ac628-9979-11e2-8406-41c12ea7a919.png)

I found the current way of adding Apps to the navigation menu using redirects in a web page rather odd.

This change adds the ability to add Apps to the menu by editing their `conf/config.php` file.  Any App with it's config file containing a non-empty `title` will be listed as a candidate for the navigation menu.  If you don't want an App shown in the menu even though it has a `title` then adding `no_nav = true` will hide it.
