### PR TITLE
Add "Edit Caption" to embedded gallery for logged-in users

### DIFF
--- a/apps/filemanager/handlers/gallery.php
+++ b/apps/filemanager/handlers/gallery.php
@@ -67,6 +67,9 @@ if ($data['style'] === 'lightbox') {
 	$template = 'filemanager/gallery';
 } else {
 	$template = 'filemanager/gallery/embedded';
+    if (User::require_admin ()) {
+        $page->add_script ('/apps/filemanager/js/jquery.filemanager.js');
+    }
 }
 
 // rewrite if proxy is set

--- a/apps/filemanager/views/gallery/embedded.html
+++ b/apps/filemanager/views/gallery/embedded.html
@@ -29,7 +29,7 @@ $(function () {
 {% foreach files %}
 <div><a href="/{{ loop_value->path }}" rel="gallery-{{ gallery }}" class="gallery" data-desc="{{ loop_value->desc }}" onclick="return $.gallery_view (this)"><img src="/{{ loop_value->path|filemanager_get_thumbnail }}" alt="" /></a>
 	{% if User::require_admin () %}
-	<a href="#" onclick="return $.filemanager ('prop', {file: '{{loop_value->path|substr(%s, 6)}}'})">{"Edit Caption"}</a>
+	<a href="#" onclick="return $.filemanager ('prop', {file: '/{{loop_value->path|FileManager::strip_webroot}}'})">{"Edit Caption"}</a>
 	{% end %}
 </div>
 {% end %}


### PR DESCRIPTION
Pops up the filemanager Properties window from a layout.  Requires `$page->add_script ('/apps/filemanager/js/jquery.filemanager.js');` in the handler and `{! filemanager/gallery?path=path/to/images&amp;style=embedded !}` in the layout.

![screenshot-2013-04-05-14:19:59](https://f.cloud.github.com/assets/3870415/345273/9b02eee2-9e1d-11e2-9a12-79214567b3a7.jpg)

![screenshot-2013-04-05-15:21:31](https://f.cloud.github.com/assets/3870415/345574/12209a62-9e26-11e2-8def-06869a2cf5ad.jpg)
