### PR TITLE
hotfix for mongo tests

### DIFF
--- a/tests/MongoModelTest.php
+++ b/tests/MongoModelTest.php
@@ -18,17 +18,25 @@ class MongoModelTest extends PHPUnit_Framework_TestCase {
 		);
 	}
 
-	protected function setUp () {
-		if (! extension_loaded ('mongo')) {
-			$this->markTestSkipped ('The Mongo extension is not available');
+	protected function setUp()
+	{
+		if (!extension_loaded('mongo')) {
+			$this->markTestSkipped('The Mongo extension is not available');
+		} else {
+			$t = new MTest ();
+			if ($t->error) {
+				$this->markTestSkipped('Unable to reach MongoDb server');
+			}
 		}
 	}
 
 	static function tearDownAfterClass () {
 		if (extension_loaded ('mongo')) {
 			$t = new MTest ();
-			foreach ($t->fetch () as $row) {
-				$row->remove ();
+			if (! $t->error) {
+				foreach ($t->fetch() as $row) {
+					$row->remove();
+				}
 			}
 			unset ($GLOBALS['conf']);
 		}


### PR DESCRIPTION
Fixes the edge case where the mongodb extension is installed but the mongodb server isn't running or available, resulting in a fatal error in class teardown and a failing rather than skipped construct test. 

Causing the construct test to be skipped rather than fail is kindof a system-specific decision based on whether the normal state should be 'running' or not. So that really should ultimately be based on a config option somewhere that indicates whether the system expects and depends on a mongo server running. Wasn't quite sure where to get that from.
