### PR TITLE
More helpful error message when ZipInstaller fails

### DIFF
--- a/apps/designer/lib/ZipInstaller.php
+++ b/apps/designer/lib/ZipInstaller.php
@@ -13,7 +13,7 @@ class ZipInstaller extends Installer {
 		try {
 			Zipper::unzip ($source['tmp_name']);
 		} catch (Exception $e) {
-			self::$error = __ ('Could not unzip the file.');
+			self::$error = $e->getMessage();
 			return false;
 		}
 


### PR DESCRIPTION
I was having fits because I couldn't get elefant's installer to work with zip files.  It turned out that I don't have zip enabled in php.ini.  This change returns "Zip file installation failed: Class 'ZipArchive' not found." instead of "Zip file installation failed: Could not unzip the file."
