### PR TITLE
Pass a list of files to be displayed to the Gallery and Slideshow.

### DIFF
--- a/apps/filemanager/handlers/slideshow.php
+++ b/apps/filemanager/handlers/slideshow.php
@@ -9,39 +9,77 @@
  *
  * The `foldername` is a folder of images inside `/files/` or the directory set
  * by the 'filemanager_path' option in your config file.
+ *
+ *  * Alternatively, it can be used via:
+ *
+ *      {! filemanager/slideshow?files=filelist&name=idsuffix !}
+ *
+ * The `filelist` is a list of images inside `/files/` or the directory set
+ * by the `filemanager_path` option in your config file.
+ * `filelist` can either be an array or a string with each file path delimited
+ * by `|`.
+ * `idsuffix` will be appended to the CSS id of the slideshow.
  */
+$root = trim (conf ('Paths', 'filemanager_path'), '/') . '/';
 
-$root = trim (conf ('Paths','filemanager_path'), '/') . '/';
+if (isset ($data['path']) or isset ($_GET['path'])) {
 
-if (isset ($data['path'])) {
-	$path = trim ($data['path'], '/');
-} elseif (isset ($_GET['path'])) {
-	$path = trim ($_GET['path'], '/');
+        if (isset ($data['path'])) {
+                $path = trim ($data['path'], '/');
+        } elseif (isset ($_GET['path'])) {
+                $path = trim ($_GET['path'], '/');
+        }
+
+        if (strpos ($path, '..') !== false) {
+                return;
+        }
+
+        if ( ! @is_dir ($root . $path)) {
+                return;
+        }
+
+        $name = str_replace ('/', '-', $path);
+
+        $files = glob ($root . $path . '/*.{jpg,jpeg,gif,png,JPG,JPEG,GIF,PNG}', GLOB_BRACE);
+        $files = is_array ($files) ? $files : array ();
+} elseif (isset ($data['files']) or isset ($_GET['files'])) {
+
+        if (isset ($data['files'])) {
+                $files_arg = $data['files'];
+        } elseif (isset ($_GET['files'])) {
+                $files_arg = $_GET['files'];
+        }
+
+        if (is_string ($files_arg)) {
+                $files = explode ('|', $files_arg);
+        } elseif (is_array ($files_arg)) {
+                $files = $files_arg;
+        } else {
+                return;
+        }
+
+        $files = array_map (
+                function($var) use ($root) {
+                        return ($root . trim ($var, '/'));
+                }
+                , $files);
+
+        if (isset ($data['name'])) {
+                $name = $data['name'];
+        } elseif (isset ($_GET['name'])) {
+                $name = $_GET['name'];
+        }
 } else {
-	return;
+        return;
 }
-
-if (strpos ($path, '..') !== false) {
-	return;
-}
-
-if (! @is_dir ($root . $path)) {
-	return;
-}
-
-$name = str_replace ('/', '-', $path);
-
-$files = glob ($root . $path . '/*.{jpg,jpeg,gif,png,JPG,JPEG,GIF,PNG}', GLOB_BRACE);
-$files = is_array ($files) ? $files : array ();
 
 // rewrite if proxy is set
 if ($appconf['General']['proxy_handler']) {
-	foreach ($files as $k => $file) {
-		$files[$k] = str_replace ('files/', 'filemanager/proxy/', $file);
-	}
+        foreach ($files as $k => $file) {
+                $files[$k] = str_replace ('files/', 'filemanager/proxy/', $file);
+        }
 }
 
-$page->add_script ('/apps/filemanager/js/jquery.cycle.all.min.js');
-echo $tpl->render ('filemanager/slideshow', array ('files' => $files, 'name' => $name));
-
+$page -> add_script ('/apps/filemanager/js/jquery.cycle.all.min.js');
+echo $tpl -> render ('filemanager/slideshow', array ('files' => $files, 'name' => $name));
 ?>


### PR DESCRIPTION
This is just an idea I've been playing with...

I've altered both the filemanager's gallery and slideshow so that you can pass either a `|` delimited string or an array that lists paths to images to be displayed.  That way, paths to images could be held in a database, for example.

As an example.  In the handler and passed to the view as part of the array argument to `render` :-

``` php
$myfiles = 'homepage/photo1.jpg|homepage/photo2.jpg';
```

or

``` php
$myfiles = array('homepage/photo1.jpg','homepage/photo2.jpg');
```

In the view:-

```
{! filemanager/slideshow?files=[myfiles|none]&name=homepage !}
```

`name` is the suffix to the slideshow's CSS ID tag which was extracted from the path in the original usage.

It's a similar scenario with the gallery, except that `name` is not used.
