### PR TITLE
fix Content-Encoded: chunked for some edge case

### DIFF
--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -515,14 +515,14 @@ class Controller {
 		$this->uri = $uri;
 		return $route;
 	}
-	
+
 	/**
 	 * Looks for an override of the current handler in the app
 	 * configuration in a `[Custom Handlers]` section. Overrides
 	 * are handlers that should be called transparently in place
 	 * of the current handler, overriding its behaviour without
 	 * modifying the original handler.
-	 * 
+	 *
 	 * An override setting's key should be the app/handler name,
 	 * and the value can be either the same app/handler name
 	 * (meaning no override), another app/handler name (meaning
@@ -548,18 +548,18 @@ class Controller {
 
 		list ($app) = explode ('/', $handler);
 		$custom = Appconf::get ($app, 'Custom Handlers', $handler);
-		
+
 		if (! $custom) {
 			// disable this handler
 			return $this->error (404, __ ('Not found'), __ ('The page you requested could not be found.'));
 		}
-		
+
 		if ($custom !== $handler) {
 			// override the handler
 			$override = count ($this->params) ? $custom . '/' . join ('/', $this->params) : $custom;
 			return $this->run ($override, $this->data, $this->internal);
 		}
-		
+
 		// no override
 		return false;
 	}
@@ -854,7 +854,10 @@ class Controller {
 			}
 		} else {
 			// Send the current output buffer contents
-			$out = ob_get_clean ();
+			$out = '';
+			while(ob_get_level() > 0) {
+				$out .= ob_get_clean ();
+			}
 			if (strlen ($out) > 0) {
 				printf ("%X\r\n", strlen ($out));
 				echo $out . "\r\n";


### PR DESCRIPTION
These seems to fix the problem I have with Content-Encoding: chunked in my setup, problem not existing in others setup... Maybe a php.ini settings about content buffering.

Anyway, without this fix, I can't get Chunked encoding working right, the output is chunk-encoded two times : the inner buffer is (partially) encoded, then the outer buffer is correctly encoded, but leaving the inner one with unfinished chunks...
