### PR TITLE
Incorrect Override for Blog/Index Handler

### DIFF
--- a/apps/blog/handlers/index.php
+++ b/apps/blog/handlers/index.php
@@ -5,7 +5,7 @@
  */
 
 // Check for a custom handler override
-$res = $this->override ('blog/post');
+$res = $this->override ('blog/index');
 if ($res) { echo $res; return; }
 
 $page->id = 'blog';


### PR DESCRIPTION
Minor typo.
The Index handler reads the handler override settings for the blog/post instead of the blog/index.
