### PR TITLE
404 Error for Blog

### DIFF
--- a/apps/blog/handlers/post.php
+++ b/apps/blog/handlers/post.php
@@ -15,6 +15,11 @@ require_once ('apps/blog/lib/Filters.php');
 
 $p = new blog\Post ($this->params[0]);
 
+// post not found
+if($p->error){
+        return $this->error(404, __('Post not found'), '<p>' . __('Hmm, we can\'t seem to find the post you wanted at the moment.') . '</p>');
+}
+
 $page->title = Appconf::blog ('Blog', 'title');
 
 $post = $p->orig ();


### PR DESCRIPTION
If a post is requested (e.g. http://www.example/com/blog/post/999) which doesn't exist, Elefant currently displays an empty post dated 1 Jan 1970.
This fixes it, so that it displays a 404 Post Not Found message.
