### PR TITLE
Remove initial "/" from filemanager property path

### DIFF
--- a/apps/filemanager/views/gallery/embedded.html
+++ b/apps/filemanager/views/gallery/embedded.html
@@ -29,7 +29,7 @@ $(function () {
 {% foreach files %}
 <div><a href="/{{ loop_value->path }}" rel="gallery-{{ gallery }}" class="gallery" data-desc="{{ loop_value->desc }}" onclick="return $.gallery_view (this)"><img src="/{{ loop_value->path|filemanager_get_thumbnail }}" alt="" /></a>
 	{% if User::require_admin () && $data->desc == 'yes' %}
-	<a href="#" onclick="return $.filemanager ('prop', {file: '/{{loop_value->path|FileManager::strip_webroot}}'})">{"Edit Caption"}</a>
+	<a href="#" onclick="return $.filemanager ('prop', {file: '{{loop_value->path|FileManager::strip_webroot}}'})">{"Edit Caption"}</a>
 	{% end %}
 </div>
 {% end %}


### PR DESCRIPTION
Captions weren't showing up because image paths were stored as `/path/to/image` instead of `path/to/image`
