### PR TITLE
Check to make sure there are any `apps/*/conf/cli.php` before globbing

### DIFF
--- a/apps/cli/handlers/index.php
+++ b/apps/cli/handlers/index.php
@@ -47,8 +47,8 @@ Commands:
 HELP;
 
 // Extend command list with those from apps/*/conf/cli.php
-if (glob ('apps/*/conf/cli.php')) {
-	$files = glob ('apps/*/conf/cli.php');
+$files = glob ('apps/*/conf/cli.php');
+if ($files) {
 	$commands = array ();
 	foreach ($files as $file) {
 		$parsed = parse_ini_file ($file);


### PR DESCRIPTION
In my version of php (5.5.6, arch linux), `elefant help` throws an error if there are no matches to `apps/*/conf/cli.php`
