### PR TITLE
Add Class = 'current' or 'active' to dropmenu

### DIFF
--- a/apps/navigation/lib/Functions.php
+++ b/apps/navigation/lib/Functions.php
@@ -66,6 +66,7 @@ function navigation_print_dropmenu ($tree, $id = false) {
 		if (empty ($current)) {
 			$current = in_array ($item->attr->id, Link::active()) ? ' class="active"' : $current;
 		}
+		echo '<li' . $current . '>' . Link::make ($item->attr->id, $item->data);
 		if (isset ($item->children)) {
 			navigation_print_level ($item->children);
 		}


### PR DESCRIPTION
Tried to make this work the same as the 'top' menu, in that class='current' or 'parent' is added to the <li>.
