### PR TITLE
adding a default charset=utf8 to master connection

### DIFF
--- a/lib/DB.php
+++ b/lib/DB.php
@@ -126,7 +126,10 @@ class DB {
 					if (strstr ($conf['host'], ':')) {
 						$conf['host'] = str_replace (':', ';port=', $conf['host']);
 					}
-					self::$connections[$id] = new PDO ($conf['driver'] . ':host=' . $conf['host'] . ';dbname=' . $conf['name'], $conf['user'], $conf['pass']);
+					if (!isset($conf['charset'])) {
+						$conf['charset']='utf8';
+					}
+					self::$connections[$id] = new PDO ($conf['driver'] . ':host=' . $conf['host'] . ';dbname=' . $conf['name'] . ';charset=' . $conf['charset'], $conf['user'], $conf['pass']);
 			}
 		} catch (PDOException $e) {
 			self::$error = $e->getMessage ();


### PR DESCRIPTION
I know at least one ISP (OVH) where this setting is necessary for having a correct charset with MySQL. Moreover, it's easier adding a new master[charset] parameter than patching the source...
