### PR TITLE
Explicit sequence name fix proposal

### DIFF
--- a/lib/DB.php
+++ b/lib/DB.php
@@ -376,8 +376,8 @@ class DB {
 	/**
 	 * Get the last inserted id value.
 	 */
-	public static function last_id () {
-		return self::$connections[self::$last_conn]->lastInsertId ();
+	public static function last_id ($name=null) {
+		return self::$connections[self::$last_conn]->lastInsertId ($name);
 	}
 	
 	/**

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -406,7 +406,7 @@ class Model {
 				return false;
 			}
 			if (! isset ($this->data[$this->key])) {
-				$this->data[$this->key] = DB::last_id ();
+				$this->data[$this->key] = (DB::get_connection(DB::$last_conn)->getAttribute(PDO::ATTR_DRIVER_NAME) == 'pgsql') ? DB::last_id(str_replace ('#prefix#', DB::$prefix, $this->table) . '_' . $this->key . '_seq') : DB::last_id();
 				$this->keyval = $this->data[$this->key];
 			}
 			$this->is_new = false;


### PR DESCRIPTION
In relation to an issue discovered with the form app incorrectly redirecting when using PostgreSQL, this proposed fix adds a catch to the `DB::last_id` setup in the model class for postgres that explicitly sends a sequence name that follows the default format of the `serial` datatype: `tablename_fieldname_seq`.

After reinstalling the form app using it's proposed SQL setup, the redirect worked correctly with this fix.
