### PR TITLE
Fix for app installer sending array instead of string.

### DIFF
--- a/apps/designer/lib/ZipInstaller.php
+++ b/apps/designer/lib/ZipInstaller.php
@@ -17,7 +17,7 @@ class ZipInstaller extends Installer {
 			return false;
 		}
 
-		$folder = Zipper::find_folder ($source);
+		$folder = Zipper::find_folder ($source['name']);
 
 		// Get config and verify it
 		if (! file_exists ($folder . '/elefant.json')) {


### PR DESCRIPTION
Issue discovered when trying to install the stripe app on a fresh master copy of elefantCMS. 

Error:  
![issue](https://cloud.githubusercontent.com/assets/1837484/3505423/5a8f8eb0-065e-11e4-958a-1a6e0e401c54.png)

Solved by adding the `['name']` array parameter shown in the commit.
