### PR TITLE
CLI Updater: version comparison fixed

### DIFF
--- a/apps/cli/handlers/update.php
+++ b/apps/cli/handlers/update.php
@@ -60,7 +60,7 @@ if ($app === 'none' || $app === 'all') {
 	}
 
 	// Are we already up to date?
-	if ($res->latest <= ELEFANT_VERSION) {
+	if (version_compare ($res->latest, ELEFANT_VERSION,'<=')) {
 		echo ELEFANT_VERSION . " is already up-to-date.\n";
 		return;
 	}


### PR DESCRIPTION
String comparison of versions does not work always correctly. For example: ('1.3.9' <= '1.3.10') ===  false
