### PR TITLE
Fix bad extended field call.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -142,6 +142,7 @@ a:hover {
 #body.index-body #slideshow-homepage img {
 	max-width: 940px;
 	width: 940px;
+	min-height:initial;
 }
 
 .index-body table td {

--- a/lib/ExtendedModel.php
+++ b/lib/ExtendedModel.php
@@ -161,7 +161,7 @@ class ExtendedModel extends Model {
 		// Pre-populate extended attributes with given default values
 		if (! empty ($defaults)) {
 			foreach ($defaults as $k => $v) {
-				if (! isset ($this->{$k})) $this->ext ($k, $v);
+				if (!$this->ext($k)) $this->ext ($k, $v);
 			}
 		}
 


### PR DESCRIPTION
Default value setting wasn't working properly. This should fix it.
Also fixed the default homepage slideshow CSS so the images won't be stretched.