### PR TITLE
Patch for postfeed.php passing data wrong

### DIFF
--- a/apps/blog/handlers/postsfeed.php
+++ b/apps/blog/handlers/postsfeed.php
@@ -35,6 +35,7 @@ if (! is_array ($posts) || count ($posts) === 0) {
 	}
 
 	foreach ($posts as $post) {
+		$post = $p->orig();
 		$post->url = '/blog/post/' . $post->id . '/' . URLify::filter ($post->title);
 		$post->tag_list = (strlen ($post->tags) > 0) ? explode (',', $post->tags) : array ();
 		$post->social_buttons = $appconf['Social Buttons'];

--- a/apps/blog/handlers/postsfeed.php
+++ b/apps/blog/handlers/postsfeed.php
@@ -34,7 +34,7 @@ if (! is_array ($posts) || count ($posts) === 0) {
 		echo '<p class="hide-in-preview"><a href="/blog/add">' . __ ('Add Blog Post') . '</a></p>';
 	}
 
-	foreach ($posts as $post) {
+	foreach ($posts as $p) {
 		$post = $p->orig();
 		$post->url = '/blog/post/' . $post->id . '/' . URLify::filter ($post->title);
 		$post->tag_list = (strlen ($post->tags) > 0) ? explode (',', $post->tags) : array ();


### PR DESCRIPTION
Postfeed.php was not sending the additional data to the view in the same way as post.php, so it couldn't find the url parameter (specifically to pass to a comments embed). This fixes that.