### PR TITLE
cURL calls: Proxy configuration added.

### DIFF
--- a/apps/designer/lib/GithubFetcher.php
+++ b/apps/designer/lib/GithubFetcher.php
@@ -71,6 +71,7 @@ class GithubFetcher {
 			curl_setopt ($ch, CURLOPT_SSL_VERIFYHOST, 0);
 			curl_setopt ($ch, CURLOPT_FAILONERROR, 0);
 			curl_setopt ($ch, CURLOPT_URL, $url);
+			curl_setproxy ($ch, $url);
 			$res = curl_exec ($ch);
 			curl_close ($ch);
 			return $res;

--- a/apps/designer/lib/ZipInstaller.php
+++ b/apps/designer/lib/ZipInstaller.php
@@ -91,6 +91,7 @@ class ZipInstaller extends Installer {
 			curl_setopt ($ch, CURLOPT_SSL_VERIFYHOST, 0);
 			curl_setopt ($ch, CURLOPT_FAILONERROR, 0);
 			curl_setopt ($ch, CURLOPT_URL, $url);
+			curl_setproxy ($ch, $url);
 			$res = curl_exec ($ch);
 			curl_close ($ch);
 		} else {

--- a/conf/config.php
+++ b/conf/config.php
@@ -245,4 +245,13 @@ transport[type] = sendmail
 ;transport[type] = file
 ;transport[folder] = cache/mailer
 
+[Proxy]
+
+; Proxy configuration for cURL.
+; Keep commented if no proxy used.
+;url = "http://1.2.3.4"
+;port = 8080
+;skip_urls = "localhost,localhost.local"
+;skip_ips = "127.0.0.1,192.168.1.1"
+
 ; */ ?>

--- a/lib/Functions.php
+++ b/lib/Functions.php
@@ -301,9 +301,44 @@ function fetch_url ($url) {
 		curl_setopt ($ch, CURLOPT_SSL_VERIFYHOST, 0);
 		curl_setopt ($ch, CURLOPT_FAILONERROR, 0);
 		curl_setopt ($ch, CURLOPT_URL, $url);
+		curl_setproxy ($ch, $url);
 		$res = curl_exec ($ch);
 		curl_close ($ch);
 		return $res;
 	}
 	return file_get_contents ($url);
+}
+
+/**
+ * Sets proxy for a curl call using global settings.
+ * 
+ * @param resource $ch
+ * @param string $url
+ */
+function curl_setproxy ($ch, $url) {
+	
+	$set_proxy = true;
+	if (conf ('Proxy', 'url') && intval (conf ('Proxy', 'port'))) {
+		if (conf ('Proxy', 'skip_urls')) {
+			if (($domain = parse_url ($url, PHP_URL_HOST))) {
+				if (in_array ($domain, explode (',', conf ('Proxy', 'skip_urls')))) {
+					$set_proxy = false;
+				}
+			}
+		}
+		if (conf ('Proxy', 'skip_ips')) {
+			if (($domain = parse_url ($url, PHP_URL_HOST))) {
+				if (($ip = gethostbyname ($domain))) {
+					if (in_array ($ip, explode (',', conf ('Proxy', 'skip_ips')))) {
+						$set_proxy = false;
+					}
+				}
+			}
+		}
+		if ($set_proxy) {
+			curl_setopt ($ch, CURLOPT_PROXY,
+				conf ('Proxy', 'url') . ':' . intval (conf ('Proxy', 'port'))
+			);			
+		}
+	}
 }


### PR DESCRIPTION
cURL calls fail In case of server behind a network proxy with no proxy properties been provided to curl.
Added global setting: [Proxy] url, port, skip_urls, skip_ips.
Added function curl_setproxy ($ch, $url) in /lib/Functions.php which sets proxy properties.
Local addresses and URLs accessed directly with no proxy parameters provided to curl.