### PR TITLE
CLI: Global settings handler: Settings of array type processing fixed

### DIFF
--- a/apps/cli/handlers/conf.php
+++ b/apps/cli/handlers/conf.php
@@ -23,7 +23,7 @@ if (! $this->cli) die ('Must be run from the command line.');
 $page->layout = false;
 
 $valid_section_name = '/^[a-zA-Z0-9 _-]+$/';
-$valid_setting_name = '/^[a-zA-Z0-9\/ _-]+$/';
+$valid_setting_name = '/^[a-zA-Z0-9\/\[\] _-]+$/';
 
 // there's a value to update
 if (isset ($_SERVER['argv'][3])) {


### PR DESCRIPTION
```bash
#./elefant conf Database.master[pass] qwerty 
```
generates an error: Invalid setting name: master[pass]

Square brackets have to be enabled in a setting name.