### PR TITLE
Use PHP_EOL for line endings

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -187,9 +187,9 @@ switch ($_GET['step']) {
 		if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 			// got the settings, save them
 			$config = file_get_contents ('../conf/config.php');
-			$config = preg_replace ('/site_name = .*(\r\n|\r|\n)/', 'site_name = "' . $_POST['site_name'] . '\1"', $config, 1);
-			$config = preg_replace ('/email_from = .*(\r\n|\r|\n)/', 'email_from = "' . $_POST['email_from'] . '\1"', $config, 1);
-			$config = preg_replace ('/site_key = .*(\r\n|\r|\n)/', 'site_key = "' . md5 (uniqid (rand (), true)) . '\1"', $config, 1);
+			$config = preg_replace ('/site_name = .*(?:\r\n|\r|\n)/', 'site_name = "' . $_POST['site_name'] . '"'. PHP_EOL, $config, 1);
+			$config = preg_replace ('/email_from = .*(?:\r\n|\r|\n)/', 'email_from = "' . $_POST['email_from'] . '"'. PHP_EOL, $config, 1);
+			$config = preg_replace ('/site_key = .*(?:\r\n|\r|\n)/', 'site_key = "' . md5 (uniqid (rand (), true)) . '"'. PHP_EOL, $config, 1);
 			if (! file_put_contents ('../conf/config.php', $config)) {
 				$data['error'] = __ ('Failed to write to conf/config.php');
 			} else {

--- a/install/index.php
+++ b/install/index.php
@@ -187,9 +187,9 @@ switch ($_GET['step']) {
 		if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 			// got the settings, save them
 			$config = file_get_contents ('../conf/config.php');
-			$config = preg_replace ('/site_name = .*/', 'site_name = "' . $_POST['site_name'] . '"', $config, 1);
-			$config = preg_replace ('/email_from = .*/', 'email_from = "' . $_POST['email_from'] . '"', $config, 1);
-			$config = preg_replace ('/site_key = .*/', 'site_key = "' . md5 (uniqid (rand (), true)) . '"', $config, 1);
+			$config = preg_replace ('/site_name = .*(\r\n|\r|\n)/', 'site_name = "' . $_POST['site_name'] . '\1"', $config, 1);
+			$config = preg_replace ('/email_from = .*(\r\n|\r|\n)/', 'email_from = "' . $_POST['email_from'] . '\1"', $config, 1);
+			$config = preg_replace ('/site_key = .*(\r\n|\r|\n)/', 'site_key = "' . md5 (uniqid (rand (), true)) . '\1"', $config, 1);
 			if (! file_put_contents ('../conf/config.php', $config)) {
 				$data['error'] = __ ('Failed to write to conf/config.php');
 			} else {

--- a/lib/Ini.php
+++ b/lib/Ini.php
@@ -100,6 +100,7 @@ class Ini {
 		}
 	
 		$out .= "\n; */ ?>";
+		$out = preg_replace("/\n/",PHP_EOL,$out);
 		if ($file === false) {
 			return $out;
 		}


### PR DESCRIPTION
This was triggering my OCD quite a bit. This way, all edited config files (I hope) will write the ENV's proper line ending using PHP_EOL.