### PR TITLE
Change Form::verify_referrer to accept empty HTTP_REFERER

### DIFF
--- a/lib/Form.php
+++ b/lib/Form.php
@@ -369,7 +369,7 @@ class Form {
 	 * since those are almost certainly abusive.
 	 */
 	public function verify_referrer () {
-		if (strpos ($_SERVER['HTTP_REFERER'], $_SERVER['HTTP_HOST']) === false) {
+		if (strpos ($_SERVER['HTTP_REFERER'], $_SERVER['HTTP_HOST']) === false && $_SERVER['HTTP_REFERER'] !== null) {
 			return false;
 		}
 		return true;


### PR DESCRIPTION
In some cases $_SERVER['HTTP_REFERER'] is not set (e.g. when using ad blockers or surfing through proxy). The function verify_referrer of class Form fails in such cases which result in a return false of Forms function submit. So in this case, forms might not be saved and the current page is only reloaded without its form content being saved.

Since that server variable can easily be spoofed, it doesn't impose a security weakening. Some bad guy who tries to manipulate by sending an *empty* referrer could as well send a *wrong* referrer.