### PR TITLE
Use url type in embedded rss viewer dialog

### DIFF
--- a/apps/blog/conf/embed.php
+++ b/apps/blog/conf/embed.php
@@ -46,8 +46,7 @@ icon = rss
 
 url[label] = RSS Link
 url[type] = text
-url[not empty] = 1
-url[regex] = "|^http://.+$|"
+url[url] = 1
 url[message] = Please enter a valid URL.
 
 [blog/postsfeed]


### PR DESCRIPTION
I couldn't get the `Blog: RSS Viewer` dynamic object to accept my feed URL.  Changing `url[not empty] = 1` to `url[url] = 1` and removing the regex in `apps/blog/conf/embed.php` allowed me to create the RSS Viewer.