### PR TITLE
Fix for missing "Delete row" in Redactor

### DIFF
--- a/apps/admin/js/redactor/plugins/table.js
+++ b/apps/admin/js/redactor/plugins/table.js
@@ -157,7 +157,7 @@
 									}
 								};
 
-				dropdown.delete_row = {
+				dropdown.delete_table = {
 									title: this.lang.get('delete_table'),
 									func: this.table.deleteTable,
 									observe: {


### PR DESCRIPTION
Redactor `table.js` had `delete_row` twice.